### PR TITLE
Use full (new) Slack webhook urls instead of tokens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Watchers can be email addresses, Slack usernames, or Slack channels.
 stakeout watch task-name jane@doe.com,#notifications,@john
 ```
 
-## Step 4. Create a cronjob for the task
+## Step 5. Create a cronjob for the task
 
 To check every minute:
 
@@ -180,7 +180,7 @@ stakeout cleanall
 
 Config for bots is stored as YAML in `~/.stakeout/config`.  You can edit it manually there.
 
-To send email notifications, you need to set a few options, especially a Mailgun API key.  To send Slack notifications, you need to set a few options, especially a Slack incoming webhook token.  You can add these all using `stakeout config` or edit them manually in `~/.stakeout/config`:
+To send email notifications, you need to set a few options, especially a Mailgun API key.  To send Slack notifications, you need to set a few options, especially a Slack incoming webhook URL.  You can add these all using `stakeout config` or edit them manually in `~/.stakeout/config`:
 
 ```
 SLACK_TOKEN: abc123
@@ -189,7 +189,7 @@ EMAIL_FROM: 'Data News Team <bots@wnyc.org>'
 EMAIL_SUBJECT_PREFIX: 'Data News Bot: '
 SLACK_NAME: Data News Bot
 SLACK_ICON: ':robot:'
-SLACK_SUBDOMAIN: datanews
+SLACK_WEBHOOK_URL: 'https://hooks.slack.com/services/ABC123...'
 tasks:
   task-name:
     ...

--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ stakeout add task-name -p /absolute/path/to/module
 
 ## Step 4. Add some people to be notified
 
-Watchers can be email addresses, Slack usernames, or Slack channels.
+Watchers can be email addresses, Slack usernames or Slack channels. Preface Slack usernames with `@`. Channel names start with `#`, which is interpreted on the command line as the start of a comment. So either enclose the whole channel name in quotes or escape the `#` using `\#`:
 
 ```
-stakeout watch task-name jane@doe.com,#notifications,@john
+stakeout watch task-name jane@doe.com,@john,'#notifications',\#botnotes
 ```
+
 
 ## Step 5. Create a cronjob for the task
 

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -31,7 +31,7 @@ silent (to fail silently, default false)
 function email(options,key) {
 
   if (!key) {
-    throw "Mailgun API key required."
+    throw "Mailgun API key required.";
   }
 
   // Is there any benefit from caching this? What is JavaScript?
@@ -58,7 +58,7 @@ function email(options,key) {
 
 Send a Slack message via incoming webhook.
 
-Requires a SLACK_TOKEN environment variable.
+Requires a SLACK_WEBHOOK_URL environment variable.
 
 notifier.slack({
   channel: "#general",
@@ -76,10 +76,10 @@ silent (to fail silently, default false)
 
 
 */
-function slack(options,token) {
+function slack(options,webhookUrl) {
 
-  if (!token) {
-    throw "Slack webhook token required."
+  if (!webhookUrl) {
+    throw "Slack webhook URL required.";
   }
 
   var payload = {
@@ -92,7 +92,7 @@ function slack(options,token) {
   // TODO: configure URL elsewhere
   request.post(
     {
-      url: "https://" + options.subdomain + ".slack.com/services/hooks/incoming-webhook?token=" + token,
+      url: webhookUrl,
       body: payload,
       json: true
     },

--- a/stakeout
+++ b/stakeout
@@ -13,8 +13,8 @@ var fs = require("fs"),
     stakeoutDir = home(".stakeout"),
     configurable = [
     {
-      name: "SLACK_TOKEN",
-      message: "Your Slack webhook token:"
+      name: "SLACK_WEBHOOK_URL",
+      message: "Your Slack webhook url:"
     },
     {
       name: "MAILGUN_API_KEY",
@@ -35,10 +35,6 @@ var fs = require("fs"),
     {
       name: "SLACK_ICON",
       message: "The emoji Stakeout should use as its icon in Slack (e.g. ':loudspeaker:'):"
-    },
-    {
-      name: "SLACK_SUBDOMAIN",
-      message: "Your organization's Slack subdomain (http://[subdomain].slack.com/):"
     }],
     config;
 
@@ -136,7 +132,7 @@ if (!program.args.length) {
 // Run all tasks
 function runall() {
 
-  for (task in config.tasks) {
+  for (var task in config.tasks) {
     run(task);
   }
 
@@ -192,7 +188,7 @@ function run(task) {
           icon: config.SLACK_ICON,
           text: notification,
           subdomain: config.SLACK_SUBDOMAIN
-        },config.SLACK_TOKEN);
+      },config.SLACK_WEBHOOK_URL);
 
       });
 


### PR DESCRIPTION
Slack no longer provides webhook tokens, instead going with webhook URLs. And those URLs no longer have the account's subdomain in them.

So to make things simpler, these changes add the full URL to the configuration, and use that for notices.